### PR TITLE
Improve CWT handling, plots, and model benchmarks

### DIFF
--- a/config/task2_config.yaml
+++ b/config/task2_config.yaml
@@ -75,3 +75,25 @@ benchmarks:
       kernel: rbf
       gamma: scale
       probability: true
+  - name: "极端随机森林"
+    type: extra_trees
+    params:
+      n_estimators: 400
+      max_depth: null
+      random_state: 42
+      class_weight: balanced
+  - name: "多层感知机"
+    type: mlp
+    params:
+      hidden_layer_sizes: [128, 64]
+      activation: relu
+      alpha: 0.0005
+      random_state: 42
+  - name: "K近邻分类器"
+    type: knn
+    params:
+      n_neighbors: 7
+      weights: distance
+  - name: "朴素贝叶斯"
+    type: gaussian_nb
+    params: {}

--- a/config/task3_config.yaml
+++ b/config/task3_config.yaml
@@ -81,3 +81,5 @@ outputs:
   pseudo_history_plot: 伪标签演化曲线.png
   tf_feature_plot: 多模态特征分布对比.png
   tf_example_plot: 多模态时频示例.png
+  tf_example_data: 多模态时频示例数据.npz
+  tf_example_metadata: 多模态时频示例信息.json

--- a/src/tasks/task2/pipeline.py
+++ b/src/tasks/task2/pipeline.py
@@ -11,8 +11,13 @@ import logging
 import numpy as np
 import pandas as pd
 from sklearn.base import clone
-from sklearn.ensemble import GradientBoostingClassifier, RandomForestClassifier
+from sklearn.discriminant_analysis import LinearDiscriminantAnalysis
+from sklearn.ensemble import ExtraTreesClassifier, GradientBoostingClassifier, RandomForestClassifier
+from sklearn.linear_model import LogisticRegression
 from sklearn.metrics import accuracy_score, f1_score
+from sklearn.naive_bayes import GaussianNB
+from sklearn.neighbors import KNeighborsClassifier
+from sklearn.neural_network import MLPClassifier
 from sklearn.pipeline import Pipeline
 from sklearn.svm import SVC
 
@@ -150,6 +155,28 @@ def _build_benchmark_estimator(spec: Dict[str, Any], random_state: int):
         params.setdefault("probability", True)
         params.setdefault("random_state", random_state)
         return SVC(**params)
+    if model_type in {"extra_trees", "extremely_randomized"}:
+        params.setdefault("n_estimators", 400)
+        params.setdefault("random_state", random_state)
+        return ExtraTreesClassifier(**params)
+    if model_type in {"logistic", "logistic_regression"}:
+        params.setdefault("max_iter", 400)
+        params.setdefault("solver", "lbfgs")
+        params.setdefault("random_state", random_state)
+        return LogisticRegression(**params)
+    if model_type in {"knn", "k_neighbors"}:
+        params.setdefault("n_neighbors", 5)
+        return KNeighborsClassifier(**params)
+    if model_type in {"mlp", "neural_network"}:
+        params.setdefault("hidden_layer_sizes", (128,))
+        params.setdefault("activation", "relu")
+        params.setdefault("random_state", random_state)
+        params.setdefault("max_iter", 500)
+        return MLPClassifier(**params)
+    if model_type in {"lda", "linear_discriminant"}:
+        return LinearDiscriminantAnalysis(**params)
+    if model_type in {"naive_bayes", "gaussian_nb"}:
+        return GaussianNB(**params)
     raise ValueError(f"Unsupported benchmark model type: {model_type}")
 
 


### PR DESCRIPTION
## Summary
- implement a SciPy-independent continuous wavelet transform helper and reuse it in the transfer pipeline while exporting multimodal intermediate data
- enhance Task 1 visualisations with log-scaled envelope spectra, stronger time-frequency saliency, and Chinese-labelled interpretability plots
- expand Task 2 benchmark comparisons with additional estimators and configuration updates

## Testing
- python -m compileall src scripts

------
https://chatgpt.com/codex/tasks/task_e_68cfd7e0f764832f89dac9466feff958