### PR TITLE
Improve feature analysis sampling and task2 visualisations

### DIFF
--- a/config/task2_config.yaml
+++ b/config/task2_config.yaml
@@ -47,12 +47,14 @@ outputs:
   metrics_file: metrics.json
   classification_report: classification_report.csv
   confusion_matrix: confusion_matrix.csv
+  confusion_matrix_plot: confusion_matrix_heatmap.png
   coefficient_importance: coefficient_importance.csv
   permutation_importance: permutation_importance.csv
   predictions: predictions.csv
   model_path: source_domain_model.joblib
   feature_summary: feature_summary.csv
   features_used: features_used.txt
+  roc_curve_plot: roc_curves.png
   model_comparison: model_comparison.csv
 
 benchmarks:


### PR DESCRIPTION
## Summary
- extend the feature analysis tooling to pick representative source samples and allow domain-specific limits so that all 16 target signals and curated source examples are visualised
- remove the DC offset from envelope spectra to fix incorrect target-domain displays
- add confusion matrix and ROC visualisations to the task 2 pipeline and expose the new artefacts in the configuration

## Testing
- python -m compileall src scripts

------
https://chatgpt.com/codex/tasks/task_e_68d0e6665c84832f86bd9988b3760236