### PR TITLE
优化特征分析可视化采样并统一中文提示

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,10 +78,10 @@ python scripts/extract_features.py --config config/dataset_config.yaml
 为了快速评估源/目标域特征的类别可分性并直观理解原始时序信号，新增了分析脚本：
 
 ```bash
-python scripts/analyze_features.py --config config/dataset_config.yaml --max-records 6 --preview-seconds 3
+python scripts/analyze_features.py --config config/dataset_config.yaml --preview-seconds 3
 ```
 
-上述示例命令中，`--max-records 6` 表示在源域/目标域的时序网格图中最多展示 6 条信号；`--preview-seconds 3` 则指定每条信号在时域预览图中截取 3 秒的数据窗口，便于放大关键细节。
+默认情况下脚本会一次性展示 **16 条目标域信号** 以及 **19 个源域代表样本**（`48kHz_Normal_data` 全部 4 条 + `12kHz_DE_data`/`12kHz_FE_data`/`48kHz_DE_data` 各自挑选 B、IR 及 OR-`Centered`/`Opposite`/`Orthogonal` 五个代表），对应“4 + 5×3”的目录覆盖策略，确保每个文件夹都能在时序网格图中出现。`--preview-seconds 3` 用于控制时域预览的秒数，仍可按需调节。若需额外限制数量，可使用 `--target-max-records` / `--source-max-records`（或 `--max-records`）覆写默认行为；如需恢复完整样本遍历，可将 `--source-preview-mode` 设为 `diverse`。
 
 脚本会在 `artifacts/analysis/`（或通过 `--analysis-dir` 指定的目录）下生成内容全面的中文可视化/报表：
 

--- a/TASK1_REPORT.md
+++ b/TASK1_REPORT.md
@@ -85,10 +85,10 @@
 运行示例：
 
 ```bash
-python scripts/analyze_features.py --config config/dataset_config.yaml --max-records 6 --preview-seconds 3
+python scripts/analyze_features.py --config config/dataset_config.yaml --preview-seconds 3
 ```
 
-输出默认存放在 `artifacts/analysis/` 目录，可通过参数 `--analysis-dir` 自定义位置。
+脚本会自动展示 16 条目标域信号与 19 个源域代表样本（`48kHz_Normal_data` 全部 4 条 + `12kHz_DE_data`/`12kHz_FE_data`/`48kHz_DE_data` 各自的 B、IR 以及 OR-`Centered`/`Opposite`/`Orthogonal` 组合，共 4 + 5×3 条），确保各工况都能在预览图中出现。输出默认存放在 `artifacts/analysis/` 目录，可通过参数 `--analysis-dir` 自定义位置。
 
 ## 执行流程回顾与结果核对
 

--- a/src/data_io/mat_loader.py
+++ b/src/data_io/mat_loader.py
@@ -192,7 +192,7 @@ def load_source_file(path: Path, default_sampling_rate: float = 12000.0) -> Opti
     variables = load_mat_variables(path)
     channels = extract_signal_channels(variables)
     if not channels:
-        LOGGER.warning("No vibration channels found in %s", path)
+        LOGGER.warning("文件 %s 中未找到振动信号通道", path)
         return None
 
     rpm = extract_rpm(variables)
@@ -231,7 +231,7 @@ def load_source_file(path: Path, default_sampling_rate: float = 12000.0) -> Opti
 
 def load_source_directory(root: Path, pattern: str = "**/*.mat", default_sampling_rate: float = 12000.0) -> List[FileSummary]:
     if not root.exists():
-        LOGGER.warning("Source directory %s does not exist", root)
+        LOGGER.warning("源域目录 %s 不存在", root)
         return []
 
     files: List[FileSummary] = []
@@ -246,7 +246,7 @@ def load_target_file(path: Path, sampling_rate: float, rpm: Optional[float]) -> 
     variables = load_mat_variables(path)
     channels = extract_signal_channels(variables)
     if not channels:
-        LOGGER.warning("Target file %s did not yield a signal channel", path)
+        LOGGER.warning("目标域文件 %s 未解析出振动通道", path)
         return None
 
     # Target domain MAT files contain only a single channel, we keep the first.
@@ -276,7 +276,7 @@ def load_target_file(path: Path, sampling_rate: float, rpm: Optional[float]) -> 
 
 def load_target_directory(root: Path, sampling_rate: float, rpm: Optional[float], pattern: str = "*.mat") -> List[FileSummary]:
     if not root.exists():
-        LOGGER.warning("Target directory %s does not exist", root)
+        LOGGER.warning("目标域目录 %s 不存在", root)
         return []
 
     files: List[FileSummary] = []


### PR DESCRIPTION
## Summary
- 更新 `scripts/analyze_features.py`，确保默认可视化覆盖 16 条目标域信号与 19 个源域代表样本，同时新增 4+5×3 目录采样分布日志、中文 CLI 帮助与 48kHz 正常样本的采样逻辑
- 调整 `src/analysis/feature_analysis.py` 与 `src/data_io/mat_loader.py` 的日志消息，统一为中文描述以便核查
- 更新 README 与 TASK1 报告中关于特征分析脚本的调用说明，反映新的默认展示数量与参数说明

## Testing
- python -m compileall src scripts

------
https://chatgpt.com/codex/tasks/task_e_68d0f649d9a8832fadadf289232088e9