### PR TITLE
docs: expand task reports with detailed pipeline notes

### DIFF
--- a/TASK3_REPORT.md
+++ b/TASK3_REPORT.md
@@ -1,103 +1,167 @@
-# 任务3：迁移诊断模型设计与实现说明
+# 任务3：迁移诊断流水线与伪标签策略深度解析
 
-本说明聚焦“任务3：迁移诊断”，即在任务1/任务2已经构建的特征与源域模型基础上，实现跨域自适应、标签推断与可视化分析。核心成果包括：多模态特征扩展、基于 CORAL 的特征对齐、伪标签自训练、域间差异度量以及端到端的脚本化流程。
+本指南面向需要理解任务3（跨域迁移诊断）全流程的开发者，结合 `src/tasks/task3` 模块、`config/task3_config.yaml` 与 `scripts/run_task3_transfer.py` 等源码，对时频特征增强、CORAL 对齐、伪标签自训练、域差异量化及可视化产物逐一拆解，帮助快速复现并扩展迁移策略。
 
-## 1. 系统架构概览
+---
+
+## 一、整体架构回顾
 
 ```
-特征表 (task1) ──▶ 时频增强 ──▶ 源域模型 (task2) ──▶ CORAL 对齐
-                                               │
-                                               ├─▶ 伪标签循环 (高置信度预测)
-                                               │
-                                               └─▶ 目标域标定 + 可视化输出
+源域特征 (task1) ─┐
+                  ├─▶ 任务2管线 (逻辑回归 + CORAL)
+目标域特征 (task1) ─┘                    │
+                                           ├─▶ 伪标签循环 (置信度 + 一致性)
+                                           │
+                                           └─▶ 可视化/指标输出 + 模型持久化
 ```
 
-所有 orchestrator 代码集中在 `src/tasks/task3/` 下：
+- **重用模块**：直接调用任务2的 `SourceDiagnosisConfig`、Pipeline 与训练逻辑，保证特征处理流程一致；
+- **能力扩展**：在源/目标特征表基础上新增 STFT/CWT/Mel 多模态特征、计算域差异指标、生成伪标签诊断图表。
 
-| 模块 | 作用 |
+---
+
+## 二、核心代码组件
+
+| 模块 | 关键类/函数 | 功能 |
+| --- | --- | --- |
+| `src/tasks/task3/configuration.py` | `parse_transfer_config` | 将 YAML 转换为 `TransferConfig`，复用任务2配置并解析时频/伪标签参数。 |
+| `src/tasks/task3/features.py` | `TimeFrequencyConfig`、`extract_time_frequency_features`、`compute_multimodal_representation` | 计算 STFT、CWT、Mel 统计以及多模态互信息一致性特征，并提供绘图所需的矩阵表示。 |
+| `src/tasks/task3/segment_loader.py` | `SegmentFetcher` | 根据特征表中的 `file_path`、`start_sample`、`end_sample` 懒加载原始时序片段，缓存 MAT 通道以避免重复 IO。 |
+| `src/tasks/task3/transfer.py` | `TransferConfig`、`PseudoLabelConfig`、`run_transfer_learning` | 迁移主流程：时频增强、源域模型训练、CORAL 对齐、伪标签循环、域对齐评估与产物封装。 |
+| `scripts/run_task3_transfer.py` | - | CLI 入口，负责读取配置、调用 `run_transfer_learning`、写出 CSV/PNG/NPZ、绘制 t-SNE 等。 |
+
+---
+
+## 三、时频特征增强机制
+
+### 3.1 STFT 特征
+
+- 使用 `scipy.signal.stft`（自动选择汉宁窗、`nperseg`、`noverlap`）计算复杂谱；
+- 统计量包括总能量、熵、频率轴的均值/标准差/偏度/峭度、时间轴重心、谱峰频率与时间；
+- 输出字段命名为 `tf_stft_*`。
+
+### 3.2 连续小波特征
+
+- 支持 `ricker`、`morlet` 等小波，若环境缺失 `signal.cwt` 则自动切换至解析/数值回退实现；
+- 统计能量熵、尺度轴统计、能量脊线总能量与平均尺度，字段前缀 `tf_cwt_*`；
+- 通过 `_fallback_cwt` 保证在 SciPy 低版本下依旧可运行。
+
+### 3.3 梅尔滤波特征
+
+- 基于 STFT 幅值构建梅尔滤波器组，支持对数幅值与指定频率范围；
+- 统计频带均值、标准差、偏度、峭度、时间重心、峰值频率/时间及对比度，字段前缀 `tf_mel_*`。
+
+### 3.4 多模态一致性
+
+- `_compute_consistency_features` 将时域能量包络与 STFT/CWT/Mel 能量沿时间轴的分布进行互信息计算；
+- 输出 `tf_consistency_*` 列，衡量模态间特征是否一致，供伪标签筛选参考。
+
+> **注意**：若段长过短或波形缺失，特征会回退为 0 并记录在日志中。
+
+---
+
+## 四、迁移主流程 (`run_transfer_learning`)
+
+1. **时频特征拼接**：
+   - 利用 `SegmentFetcher` 从原始 MAT 取出每段时序，计算 `tf_*`、`tf_consistency_*` 并与原特征表按列拼接；
+   - 若某段无法取样（文件缺失、索引越界），对应行填空字典并记录缺失数量。
+2. **源域模型训练**：
+   - 调用任务2的 `train_source_domain_model`，得到 `TrainingResult` 与初始 Pipeline；
+   - `feature_columns` 中会自动包含 `tf_*` 特征，保留 CORAL 对齐能力。
+3. **目标域对齐与初始预测**：
+   - 通过 `_set_target_statistics` 将目标域均值/协方差注入 CORAL；
+   - `_predict_with_pipeline` 输出初始预测 (`target_predictions_initial.csv`)，包含概率与指定元数据列。
+4. **伪标签循环**：
+   - `_apply_pseudo_labelling` 每轮根据 `confidence_threshold`、`consistency_threshold` 选择高置信度段；
+   - 支持 `max_iterations` 与 `max_ratio` 限制伪标签数量，避免过拟合；
+   - 每轮都会重新克隆 Pipeline、合并伪标签重新训练，并更新 CORAL 目标统计。
+5. **域对齐评估**：
+   - `compute_domain_alignment_metrics` 计算对齐前/后 MMD、CORAL 距离等指标，并输出 `alignment_before/after.csv`；
+   - 同时生成 t-SNE (`tsne_before.png`, `tsne_after.png`)，比较源/目标域嵌入。
+6. **产物汇总**：
+   - 返回 `TransferResult`，包含源/目标增强特征、伪标签记录、最终预测、时间频率特征列表、一致性特征列表等。
+
+---
+
+## 五、伪标签质量控制
+
+### 5.1 一致性度量
+
+- `_identify_modal_feature_groups` 根据特征前缀将列划分为时域、STFT、CWT、Mel 四组；
+- `_evaluate_multimodal_consistency` 对目标样本执行近邻投票，比较模型预测与各模态投票是否一致，并计算均值作为 `consistency_score`；
+- 伪标签只有同时满足概率与一致性阈值才会被采纳，相关细节保存在 `pseudo_label_quality.csv`。
+
+### 5.2 产物说明
+
+| 文件/图表 | 说明 |
 | --- | --- |
-| `features.py` | 计算 STFT/CWT 统计量，生成 `tf_*` 多模态特征。 |
-| `segment_loader.py` | 根据特征表提供的 `file_path/start_sample/end_sample` 动态截取原始时序片段。 |
-| `configuration.py` | 解析 YAML 配置，复用任务2的 `SourceDiagnosisConfig`，并扩展时频/伪标签参数。 |
-| `transfer.py` | 封装迁移诊断主流程：特征增强、模型训练、CORAL 对齐、伪标签迭代、对齐诊断、预测输出。 |
-| `scripts/run_task3_transfer.py` | 命令行入口，串联配置解析、特征读写、可视化导出与模型存档。 |
+| `pseudo_labels.csv` | 被采纳的目标段（包含预测标签、置信度、一致性得分、伪标签轮次）。 |
+| `pseudo_history.csv` | 每轮新增/累计伪标签数、平均置信度/一致性等统计。 |
+| `伪标签演化曲线.png` | 双轴展示新增 vs 累计样本数，并叠加置信度/一致性曲线。 |
+| `伪标签一致性散点.png` | 以颜色区分伪标签轮次，展示 `max_probability` vs `consistency_score`，星号标记已采纳样本。 |
+| `伪标签一致性明细.csv` | （配置中的 `pseudo_quality`）与散点图一一对应，方便人工审查。 |
 
-## 2. 多模态特征设计
+---
 
-1. **时频表征**：
-   - **STFT**：提取谱能量、熵、频率/时间矩统计量（均值、标准差、偏度、峭度）以及能量峰所在的时间/频率位置。
-   - **CWT**：基于 Ricker 小波获取不同尺度能量分布，计算尺度轴的均值、方差、偏度、峭度及主脊能量。
-   - 所有特征统一以 `tf_stft_*`、`tf_cwt_*` 前缀输出，可根据需要在配置中选择性启用/关闭。
+## 六、域间差异与多模态可视化
 
-2. **兼容性**：
-   - 若原始时序缺失或长度不足，系统自动回落为 NaN，并在日志中提示跳过的段数；后续由 `SimpleImputer` 补全，不影响训练。
-   - 新增特征同时纳入 `scripts/analyze_features.py` 的统计与翻译词典，任务1/2/3 保持统一特征命名体系。
+1. **域对齐表**：`combined_features_before/aligned.csv` 合并源/目标特征，并附带 `dataset`、`label` 列便于后续绘制；
+2. **指标文件**：`metrics.json` 记录基础训练指标、伪标签数量、最终特征维度等关键信息；
+3. **多模态示例**：
+   - `多模态特征分布对比.png` 对 `tf_*` 关键特征绘制均值±标准差条形图，突出源/目标差异；
+   - `多模态时频示例.png` + `*.npz`/`*.json` 保存置信度最高样本的波形、STFT、CWT、Mel 矩阵，可直接用于报告；
+   - `time_frequency_features.txt` 记录所有新增时频特征名称，便于下游筛选。
 
-## 3. 迁移学习策略
+---
 
-1. **源域模型复用**：
-   - 直接调用任务2管线（`train_source_domain_model`）训练逻辑回归 + CORAL 对齐模型，免去重复开发。
-   - 训练完成后，使用目标域特征均值/协方差更新 CORAL 的 `set_target_statistics`，完成一次性对齐。
+## 七、配置文件关键项 (`config/task3_config.yaml`)
 
-2. **伪标签循环**：
-   - 在 `confidence_threshold` 设定的置信区间内选择目标域样本，赋予预测标签加入训练集。
-   - 每次迭代都会 `clone` 原管线重新拟合，随后重新计算目标域统计量，最多循环 `max_iterations` 次，并限制伪标签总量不超过源域样本的 `max_ratio`。
-   - 输出 `pseudo_labels.csv` 和 `pseudo_history.csv` 记录每轮新增样本数、置信度统计等指标。
+| 配置段 | 字段 | 说明 |
+| --- | --- | --- |
+| `features` | `source_table`、`target_table` | 任务1输出路径；`metadata_columns` 控制预测结果中保留的元数据列。 |
+| `modeling` | 同任务2 | 复用逻辑回归 + CORAL 配置，可按需调整。 |
+| `time_frequency` | `stft`、`cwt`、`mel`、`consistency_bins` | 控制时频特征的窗口、尺度、滤波器数量、互信息直方图分箱。 |
+| `pseudo_label` | `enabled`、`confidence_threshold`、`max_iterations`、`max_ratio`、`consistency_threshold` | 伪标签策略。 |
+| `outputs` | 各种 CSV/PNG/NPZ 文件名 | 可按需重命名或指定目录。 |
 
-3. **对齐诊断**：
-   - 前/后的特征组合分别保存为 `combined_features_before.csv`、`combined_features_aligned.csv`，并计算 MMD/CORAL 距离（`alignment_before.csv`、`alignment_after.csv`），用于量化域间差异。
-   - 自动绘制 t-SNE（before/after），直观展示对齐效果。
+---
 
-## 4. 使用说明
+## 八、运行流程与日志观察
 
 ```bash
 python scripts/run_task3_transfer.py \
     --config config/task3_config.yaml \
-    --source-features artifacts/source_features.csv \
-    --target-features artifacts/target_features.csv
+    --source-features artifacts/task1/source_features.csv \
+    --target-features artifacts/task1/target_features.csv \
+    --output-dir artifacts/task3_experiment
 ```
 
-输出默认保存在 `artifacts/task3/`：
-
-- `target_predictions_initial.csv` / `target_predictions.csv`：目标域段级预测与概率，前者为伪标签前，后者为伪标签后的最终结果。
-- `pseudo_labels.csv`、`pseudo_history.csv`：伪标签详情及各轮统计。
-- `alignment_before.csv`、`alignment_after.csv`：域对齐指标；配套 `tsne_before.png`、`tsne_after.png`。
-- t-SNE 可视化的右侧子图使用“源域真实标签 + 目标域预测标签”着色，可直观比较伪标签前后的分类边界变化。
-- `combined_features_before/aligned.csv`：对齐前后的特征矩阵（含 `dataset` 列），方便后续分析。
-- `transfer_model.joblib`：最终迁移模型，可供任务4加载解释。
-- `metrics.json`：汇总了源域训练指标、伪标签规模、特征数量等关键信息。
-- `pseudo_label_quality.csv`：逐段记录各轮伪标签筛选时的最大置信度、多模态一致性、双阈值是否满足以及是否被采纳，配合散点图定位每个点的来源。
-- `伪标签演化曲线.png`：双轴展示每轮新增伪标签数量、累计规模及平均置信度/一致性，并标注阈值，便于评估自训练收敛情况。
-- `多模态特征分布对比.png`：基于效应量 (Cohen's d) 与相对差值对比源/目标域关键 `tf_*` 特征的均值±标准差，突出迁移前后的差异。
-- `伪标签一致性散点.png`：以颜色编码伪标签迭代轮次，叠加阈值区域与自适应趋势线；星号标记代表已采纳伪标签，圆点则代表仍未满足双阈值的候选样本，可直观对照 `pseudo_label_quality.csv` 中的布尔标记。
-- `多模态时频示例.png`：基于置信度最高的目标样本绘制时域波形、STFT 与 CWT 图像，保留中文标签用于报告展示。
-
-## 5. 输出成果与核查
-
-- **关键指标**：`metrics.json` 会记录基础模型（task2）在源域的性能、伪标签数量以及最终特征维度，建议在每次实验后与任务2的指标对比，确保迁移过程中未显著退化。
-- **伪标签质量**：`pseudo_history.csv`、`pseudo_label_quality.csv`、`伪标签演化曲线.png` 与升级后的 `伪标签一致性散点.png` 展示迭代过程中的新增样本、置信度与一致性分布；若曲线在前几轮即趋于平稳且散点集中在双阈值区域，说明阈值设置合理；若波动剧烈，可考虑降低 `max_iterations` 或提高阈值。
-- **域对齐验证**：通过 `alignment_before.csv`、`alignment_after.csv` 以及两张 t-SNE 图，可以确认 CORAL + 伪标签是否有效缩小了分布差异。若 `alignment_after` 仍显示较大的 MMD，可尝试加入更多时频特征或调整窗口长度。
-- **预测结果**：`target_predictions_initial.csv` 与 `target_predictions.csv` 支持对比伪标签前后的类别分布，可结合 `pseudo_labels.csv` 检查高置信度样本是否集中于特定通道/文件，以防止偏差。
-- **多模态示例**：`多模态时频示例.png` 与配套的 `*.npz`/`*.json` 元数据帮助复现置信度最高样本的全套特征，可用于专家复核或撰写案例分析。
-
-## 6. 结果解读建议
-
-1. **关注对齐效果**：`alignment_after` 中 MMD/CORAL 应显著低于对齐前；若下降不明显，可调节 CORAL epsilon 或增加伪标签迭代。
-2. **伪标签质量**：检查 `pseudo_history.csv` 的 `probability_mean/min/max`，若置信度分布过低，需提高阈值或减少迭代次数。
-3. **特征贡献**：可以结合任务4的解释性输出，评估时频特征在目标域的贡献度，判断是否需要进一步的多模态扩展（如 GAF、时频图像 CNN 等）。
-
-## 7. 多模态拓展思路
-
-- **原始图像流**：利用已保存的 STFT/CWT 中间矩阵生成热力图（可扩展为第三方 CNN/Transformer 输入）。
-- **互信息约束**：在伪标签阶段引入多模态一致性（如时域特征与时频特征的互信息最大化），增强跨域鲁棒性。
-- **多源融合**：若有多个目标域，可基于本架构引入多源 CORAL/对抗式自编码器，进一步提升泛化能力。
-
-### 2025-09-22 可视化与诊断升级
-
-- **散点图信息量增强**：伪标签一致性散点现在覆盖全部目标段，自动区分“通过/未通过双阈值”的候选样本，并在样本数量不足时跳过趋势拟合，彻底消除 `RankWarning` 与 `RuntimeWarning`。
-- **质量数据对齐**：`pseudo_label_quality.csv` 提供与散点图一一对应的置信度、一致性、阈值判定及是否采纳的标签，可用于快速定位异常点并生成说明。
-- **日志降噪**：近乎常数特征、SciPy 小波回退等常规提醒降级为 `INFO`，在批量实验时更容易聚焦真正异常的告警。
+- 关键日志：
+  - `INFO`：时频增强完成、源域模型训练、伪标签轮次、对齐指标写入；
+  - `WARNING`：段数据缺失、CWT/STFT 回退、伪标签数量超限等；
+  - `DEBUG`（手动开启）：打印每轮伪标签选中的索引与特征数量。
 
 ---
 
-任务3的输出直接馈入任务4的解释性分析，无需额外转换。更多实现细节请参考 `src/tasks/task3/transfer.py` 及 `scripts/run_task3_transfer.py`。
+## 九、结果解读建议
+
+1. **伪标签收敛**：观察 `伪标签演化曲线.png`，若前几轮迅速饱和且置信度稳定，说明阈值合理；反之可调高阈值或减少迭代。
+2. **一致性筛查**：结合 `伪标签一致性散点.png` 与 `伪标签一致性明细.csv`，确认被采纳样本分布是否集中在某些通道/文件，避免偏差。
+3. **域对齐效果**：比较 `alignment_before/after.csv` 中 MMD、CORAL 距离是否下降；若无改善，可增补时频特征或尝试更深度的对齐方法。
+4. **目标预测分布**：对比 `target_predictions_initial.csv` 与 `target_predictions.csv`，评估伪标签是否改善了类别分布与置信度。
+5. **多模态特征差异**：阅读 `多模态特征分布对比.png`，识别目标域在特定模态上的能量偏移，为下一轮数据收集或特征工程提供依据。
+
+---
+
+## 十、常见问题排查
+
+| 现象 | 原因 | 解决办法 |
+| --- | --- | --- |
+| `Segment too short for STFT` | 滑窗长度过小 | 增大 `window_seconds` 或禁用时频特征。 |
+| 伪标签数量始终为 0 | 阈值过高或一致性不足 | 降低 `confidence_threshold`、`consistency_threshold`，或放宽 `max_ratio`。 |
+| `target_predictions.csv` 概率分布异常 | CORAL 对齐未更新 | 检查 `_set_target_statistics` 是否被调用，或调大 `epsilon`。 |
+| `alignment_after` 指标比 `alignment_before` 更差 | 伪标签引入噪声 | 调整伪标签轮次、限制最大比例或手动过滤 `pseudo_labels.csv`。 |
+
+---
+
+通过本指南，读者可快速理解任务3迁移诊断的实现要点，并在此基础上调整时频参数、伪标签策略或域对齐手段，构建更适合自身数据的迁移流程。

--- a/TASK4_REPORT.md
+++ b/TASK4_REPORT.md
@@ -1,78 +1,157 @@
-# 任务4：迁移诊断可解释性分析说明
+# 任务4：迁移诊断可解释性产线全景
 
-本说明针对“任务4：迁移诊断可解释性”，展示如何在任务3的迁移模型基础上，从全局、域间、样本级三个层面对模型决策进行解释，并生成图表/数据报告，提升诊断人员的透明度与信任度。
+本说明聚焦任务4（迁移模型的可解释性分析），结合 `src/tasks/task4/interpretability.py`、`scripts/run_task4_interpretability.py`、`config/task4_config.yaml` 与任务3输出，详细拆解全局/域间/局部解释、聚类对比及产物结构，帮助读者在迁移模型之上建立可信的诊断结论。
 
-## 1. 可解释性框架
+---
 
-| 层次 | 工具 | 输出 | 目的 |
+## 一、框架概览
+
+| 层次 | 目标 | 核心实现 | 输出物 |
 | --- | --- | --- | --- |
-| 全局 | 逻辑回归系数 + 特征翻译词典 | `global_feature_effects.csv`、`global_feature_categories.csv`、`global_importance.png` | 识别对各故障类别最关键的特征，理解其物理含义。 |
-| 域间 | 特征均值差值 × 系数 | `domain_shift_contributions.csv`、`domain_shift.png` | 定量评估源/目标域分布差异对模型 logit 的影响方向与幅度。 |
-| 局部 | 特征贡献分解 | `local_explanation.csv`、`local_explanation.png` | 对单条样本给出“贡献度排序”，辅助专家验证模型判断。 |
+| 全局解释 | 评估各特征对不同故障类别的总体贡献 | 逻辑回归系数或 SHAP KernelExplainer | `global_feature_effects.csv`、`global_feature_categories.csv`、`global_importance.png` |
+| 域间解释 | 量化源/目标域均值差异对 logit 的影响 | `compute_domain_shift_contributions` | `domain_shift_contributions.csv`、`domain_shift.png` |
+| 局部解释 | 对单条样本分解特征贡献并可视化 | `explain_samples` + SHAP/LIME/线性贡献 | `local_explanation.csv`、`local_explanation.png` |
+| 局部聚类 | 比较多个样本的贡献模式 | `cluster_local_explanations` | `local_cluster_assignments.csv`、`local_cluster_profiles.csv`、`local_cluster_heatmap.png` |
 
-底层实现位于 `src/tasks/task4/interpretability.py`，主要函数包括：
+---
 
-- `compute_global_feature_effects`：统计每个类别/特征的系数、绝对系数与赔率比，并按特征类别聚合。
-- `compute_domain_shift_contributions`：比较源/目标域特征均值差异，乘以系数得到 logit 贡献；输出中文类别列并在绘图时按“特征×类别”分组，便于定位造成域偏移的关键因素。
-- `explain_instance`：提取单条样本经 pipeline 变换后的特征向量，与系数相乘得到 logit 贡献，同时保留原始取值与目标类别中文名称，便于理解幅度。
-- 三个 `plot_*` 方法负责绘制水平条形图，默认自动控制纵轴密度，保证在多个特征时仍易于阅读。
+## 二、运行入口与依赖关系
 
-## 2. 运行方式
+1. `scripts/run_task4_interpretability.py` 负责：
+   - 解析 YAML，加载任务1特征表；
+   - 调用任务3的 `parse_transfer_config` 并执行 `run_transfer_learning` 以获得最新的迁移模型与伪标签；
+   - 依次运行全局解释、域间贡献、局部解释、聚类分析，并写出图表/报表；
+   - 汇总生成 `interpretability_summary.json`，记录本次解释的关键统计。
+2. 因此**任务4会重新执行任务3的迁移流程**：确保配置保持一致，以避免解释与实际模型不符；如需直接复用现有模型，可在代码中扩展加载逻辑。
+
+---
+
+## 三、全局解释模块
+
+### 3.1 数据准备
+
+- `compute_global_feature_effects` 首先通过 `_build_feature_metadata` 调用 `feature_dictionary.py` 获取中文名称与特征类别；
+- `build_label_name_map` 将类别编码映射为中文（如 `outer_race_fault` → “外圈故障”）。
+
+### 3.2 线性解释（默认）
+
+- 当分类器提供 `coef_` 时，直接按类别遍历权重：
+  - 输出列包括 `类别编码`、`类别`、`特征编码`、`影响值`（系数）、`重要性`（绝对值）、`优势比`；
+  - 同时记录截距（标记为 `__intercept__`），在图表中作为“基线贡献”。
+- `global_feature_categories.csv` 将特征按类别聚合（时域/频域/包络/故障带/时频等），统计绝对贡献总和，便于宏观对比。
+
+### 3.3 SHAP 解释（可选）
+
+- 当 `method=shap` 或分类器无系数时，使用 Kernel SHAP：
+  - `shap.kmeans` 自动压缩背景数据（默认为 200 条），减少计算量；
+  - `mean_contribution` 与 `mean_absolute` 分别表示平均贡献值与绝对贡献值；
+  - 输出格式与线性解释一致，但“基线贡献”对应 `expected_value`。
+
+### 3.4 可视化
+
+- `plot_global_importance` 从 `global_feature_effects.csv` 中选取绝对贡献 Top-N 特征绘制水平条形图，中文标签来自特征词典；
+- 图中可同时展示多个类别（堆叠条形），比较不同故障的贡献差异。
+
+---
+
+## 四、域间贡献分析
+
+1. `compute_domain_shift_contributions` 步骤：
+   - 使用迁移结果中的源/目标增强特征，按列计算均值差 `delta`；
+   - 将差值与逻辑回归系数相乘，得到每个特征对 logit 的贡献变化 `logit_contribution`；
+   - 输出中包含类别编码、中文标签、特征中文名，方便直接写入报告。
+2. `plot_domain_shift` 以 Top-N 绝对贡献为横向条形图，区分正负方向，可快速定位导致域偏移的关键特征。
+3. 应用建议：
+   - 若某些时频特征在目标域产生强烈负向贡献，可能需要在任务3阶段提高一致性阈值或重新对齐；
+   - 结合 `pseudo_labels.csv` 检查偏移是否来自特定伪标签样本。
+
+---
+
+## 五、局部解释与聚类
+
+### 5.1 核心流程
+
+1. `explain_samples` 支持三种模式：
+   - `method=auto`：线性模型走系数路径，其余模型使用 SHAP；
+   - `method=shap`：指定背景样本数 (`shap_background`) 与采样次数 (`shap_nsamples`)；
+   - `method=lime`：调用 LIME（需要 scikit-image 等依赖），可通过 `num_samples`、`random_state` 控制稳定性。
+2. 输出 `local_explanation.csv`：
+   - 包含样本索引、所属数据域（源/目标/伪标签）、目标类别、特征原值/模型输入值、贡献值、贡献绝对值等；
+   - `特征中文名` 与 `类别` 均已翻译，便于专家查阅。
+3. `plot_local_explanation` 从单个样本的贡献表中选取 Top-N 绘制水平条形图，区分正负贡献。
+
+### 5.2 聚类对比
+
+- 当配置中 `cluster.enabled=true` 且选择了多个样本时：
+  - `cluster_local_explanations` 对样本贡献向量执行 KMeans（默认聚类数 = 3），得到 `local_cluster_assignments.csv`；
+  - `local_cluster_profiles.csv` 汇总每个聚类的平均贡献 Top-N 特征；
+  - `plot_local_cluster_heatmap` 生成热力图，展示不同聚类的贡献模式差异。
+- 使用提示：聚类能帮助识别“同类故障但贡献模式不同”的情况，适合在伪标签验证或疑难告警复核中使用。
+
+---
+
+## 六、配置文件关键项 (`config/task4_config.yaml`)
+
+| 配置段 | 字段 | 说明 |
+| --- | --- | --- |
+| `features` | `source_table`、`target_table` | 引用任务1特征表，支持命令行覆盖。 |
+| `modeling` | 同任务3 | 确保与迁移模型一致，以获取可复现的 Pipeline。 |
+| `time_frequency`、`pseudo_label` | - | 复用任务3配置，影响重新训练时的时频特征与伪标签行为。 |
+| `global_importance` | `method`、`shap_background`、`shap_nsamples`、`top_n` | 控制全局解释方式与绘图 Top-N。 |
+| `domain_shift` | `top_n` | 域偏移图展示的特征数量。 |
+| `local_explanation` | `dataset`、`indices`、`class`、`method`、`top_n` 以及 SHAP/LIME 子配置 | 指定需要解释的样本、目标类别及方法。 |
+| `outputs` | 各类 CSV/PNG/JSON 路径 | 自定义产物存储位置。 |
+
+---
+
+## 七、运行命令与日志
 
 ```bash
 python scripts/run_task4_interpretability.py \
     --config config/task4_config.yaml \
-    --source-features artifacts/source_features.csv \
-    --target-features artifacts/target_features.csv
+    --source-features artifacts/task1/source_features.csv \
+    --target-features artifacts/task1/target_features.csv \
+    --output-dir artifacts/task4_experiment
 ```
 
-配置与任务3保持一致，若有额外需求（如更换局部解释的样本索引/类别），可在 `local_explanation` 节下调整。输出目录默认为 `artifacts/task4/`：
-
-- `global_feature_effects.csv`：按类别列出所有特征的系数、绝对值、赔率比，并附上中文释义与特征类别。
-- `global_feature_categories.csv`：按类别汇总绝对系数和，便于宏观判断“时域/频域/包络/时频”等模块的重要性。
-- `domain_shift_contributions.csv`：每个类别下的 `logit_contribution` 与 `delta`（均值差），配合 `domain_shift.png` 的分组水平条形图快速识别正负影响。
-- `local_explanation.csv`：指定样本的特征贡献明细，包括原始值、模型输入值、系数、logit 贡献及目标类别中文名称，辅助专家复核。
-- 三张 PNG 图对应该三张表格，便于直接放入报告或演示文稿。
-- `interpretability_summary.json` 汇总了特征数量、伪标签规模、局部解释所选样本等关键信息。
-
-## 3. 成果核查与实践经验
-
-- **全局解释审阅**：打开 `global_feature_effects.csv` 后，可按“重要性”列排序，确认关键特征与任务1/2的数据字典保持一致。配套的 `global_importance.png` 采用中文标注，可直接插入汇报材料。
-- **域偏移排查**：`domain_shift_contributions.csv` 的 `Logit贡献` 列越大，说明该特征对域偏移影响越强。结合 `domain_shift.png` 的正负条形图，可以迅速定位需要重新对齐或归一化的特征。
-- **局部解释复核**：`local_explanation.csv` 中的 `贡献值` 列与 `local_explanation.png` 的条形图互为验证。建议将同一故障的多个样本加入 `indices` 配置，生成 `local_cluster_heatmap.png`，观察贡献模式是否稳定。
-- **指标总结**：`interpretability_summary.json` 提供本次解释任务的统计信息（特征数量、伪标签规模、聚类数量等），方便在实验记录表中登记，形成可追溯的实验链路。
-
-## 4. 分析建议
-
-1. **全局层面**：
-   - 对比 `global_feature_effects.csv` 与任务1/2的特征翻译词典，验证高权重特征是否符合轴承机理（如 `fault_bpfo_band_energy` 对外圈故障应为正贡献）。
-   - 若发现“反常”权重，可回溯对应特征的提取逻辑或伪标签质量。
-
-2. **域间层面**：
-   - 重点关注 `logit_contribution` 绝对值大的特征，若某一特征在目标域显著偏移且导致 logit 增大，可考虑在任务3增加该特征的对齐力度或做归一化。
-   - `delta` 的符号揭示了目标域均值与源域的偏离方向，结合伪标签可判断该偏移是否合理。
-
-3. **局部层面**：
-   - 通过 `local_explanation.csv` 可以快速锁定某条告警的关键特征，若贡献主要来自时频特征，说明多模态增强发挥作用。
-   - 可多选几个样本（修改配置中的 `index` 和 `class`）比较不同故障的贡献模式，以形成经验库。
-
-## 5. 与任务3的衔接
-
-- `scripts/run_task4_interpretability.py` 内部会复用任务3相同的配置解析逻辑并重新运行 `run_transfer_learning`，保证解释结果与最新模型保持一致。
-- 若已执行任务3并生成 `transfer_model.joblib` 等输出，可直接将其作为先验，或在任务4中调整配置再次训练，以便开展“对照试验”（例如关闭伪标签、仅保留时域特征等）。
-
-## 6. 后续拓展方向
-
-- **更细粒度的局部解释**：可在 `explain_instance` 基础上，引入 SHAP/LIME 等方法，对非线性模型或深度模型进行扩展。
-- **跨样本对比**：对多条样本的贡献结果进行聚类或可视化，挖掘不同故障类型在目标域的共性差异。
-- **人机交互面板**：利用导出的 CSV/PNG，可进一步开发交互式看板，实现“点击样本 → 展示贡献度 → 调整阈值”的工作流。
-
-### 2025-09-22 性能与稳定性优化
-
-- **SHAP 背景聚类**：全局与局部的 KernelExplainer 均引入 `shap.kmeans` 背景压缩，自动将 200+ 背景样本浓缩为约 √N 个代表点，显著降低解释阶段的运算时间。
-- **标签映射修复**：`_build_label_mapping` 兼容 NumPy 数组输入，彻底解决“ValueError: The truth value of an array...” 的二义性异常，确保任务4在不同 sklearn 版本下稳定运行。
-- **日志降噪**：保持 `INFO` 级别提示常规回退逻辑（如缺失 SciPy CWT 函数），避免解释性脚本被非关键警告淹没。
+- 日志关注点：
+  - `INFO`：迁移流程完成、全局/域间/局部解释写出、聚类结果生成；
+  - `WARNING`：SHAP/LIME 依赖缺失、样本索引越界、聚类样本不足等；
+  - `DEBUG`（需手动启用）：打印背景样本数量、局部解释特征排序等。
 
 ---
 
-任务4提供了贯通全局-局部、多模态-时域的解释性框架，为后续撰写建模报告、与领域专家沟通提供了坚实的数据与可视化支撑。
+## 八、结果解读指南
+
+1. **全局层面**：
+   - 对比 `global_feature_categories.csv` 评估各特征族（时域/频域/时频等）的总体重要性；
+   - 若发现权重与物理机理不符（如外圈故障的 BPFO 能量为负贡献），需要回溯任务1/3 的特征提取或伪标签质量。
+2. **域间层面**：
+   - `domain_shift.png` 中的正负条形提示目标域比源域更倾向/更弱的故障模式，可结合现场工况解释；
+   - 若某些特征导致明显偏移，可调整任务3的伪标签阈值或在配置中禁用相关特征。
+3. **局部层面**：
+   - `local_explanation.png` 展示单条告警的主要驱动因子，推荐与任务3的 `多模态时频示例.png` 联合审查；
+   - 若多条样本的贡献模式差异大，可使用聚类热力图寻找规律。
+
+---
+
+## 九、常见问题排查
+
+| 现象 | 可能原因 | 建议处理 |
+| --- | --- | --- |
+| SHAP 运行缓慢或内存占用高 | 背景样本过多、特征维度大 | 降低 `shap_background` 或选择线性解释；必要时先降维。 |
+| 局部解释结果为空 | 指定索引不在对应数据域或模型预测失败 | 确认 `dataset`/`indices` 设置正确，检查任务3 产物。 |
+| 聚类热力图缺失 | 样本数量不足或聚类关闭 | 增加待解释样本数量，或在配置中关闭 `cluster`。 |
+| 域间贡献方向异常 | 目标域数据分布极端或伪标签偏差 | 检查 `pseudo_labels.csv`，必要时重新运行任务3 并调节阈值。 |
+
+---
+
+## 十、与前序任务的协同
+
+- 任务1的数据字典与特征命名直接影响可解释性报表的可读性，保持列名一致至关重要；
+- 任务2的 `coefficient_importance.csv` 与任务3的伪标签质量报告是校验解释结果的重要依据；
+- 如需在任务4中引入其他模型（如随机森林），可沿用 `run_transfer_learning` 的输出并扩展解释函数以支持特定算法。
+
+---
+
+通过上述说明，使用者可以快速定位任务4各模块的作用、配置参数与产出文件，构建完整的跨域诊断可解释性分析链路。


### PR DESCRIPTION
## Summary
- rewrite the four task reports with deeper explanations of the code modules and processing pipeline
- document configuration options, generated artifacts, and troubleshooting guidance for each stage
- highlight how the task outputs connect to downstream analysis and interpretability workflows

## Testing
- not run (documentation changes only)

------
https://chatgpt.com/codex/tasks/task_e_68d20f50bf64832f97a955eafa0dbfcf